### PR TITLE
fix: Mac build issues

### DIFF
--- a/Makefile_mac.mk
+++ b/Makefile_mac.mk
@@ -43,14 +43,14 @@ install: $(ARC)
 	@mkdir -p $(INSTALL_DIR)/include/$(LIB)/pc
 
 	@cp $(LIBDIR)/$(ARC) $(INSTALL_DIR)/lib
-	@cp $(LIBDIR)/$(DLL) $(INSTALL_DIR)/lib
+# @cp $(LIBDIR)/$(DLL) $(INSTALL_DIR)/lib
 
 	@cp $(LIBHDR) $(INSTALL_DIR)/include
 	@cp $(HDRS_X) $(INSTALL_DIR)/include/$(LIB)
 	@cp $(HDRS_PC) $(INSTALL_DIR)/include/$(LIB)/pc
 
 # UFBX library
-	@mkdir -p $(INSTALL_DIR)/include/$(LIB)/fbx
+	@mkdir -p $(INSTALL_DIR)/include/$(LIB)/ufbx
 	@cp $(UFBX_HDR) $(INSTALL_DIR)/include/$(LIB)/ufbx
 # ccVector library
 	@mkdir -p $(INSTALL_DIR)/include/$(LIB)/ccVector

--- a/Makefile_mac.mk
+++ b/Makefile_mac.mk
@@ -43,7 +43,7 @@ install: $(ARC)
 	@mkdir -p $(INSTALL_DIR)/include/$(LIB)/pc
 
 	@cp $(LIBDIR)/$(ARC) $(INSTALL_DIR)/lib
-# @cp $(LIBDIR)/$(DLL) $(INSTALL_DIR)/lib
+	@cp $(LIBDIR)/$(DLL) $(INSTALL_DIR)/lib
 
 	@cp $(LIBHDR) $(INSTALL_DIR)/include
 	@cp $(HDRS_X) $(INSTALL_DIR)/include/$(LIB)

--- a/source/cross/mgdl-light.cpp
+++ b/source/cross/mgdl-light.cpp
@@ -1,3 +1,4 @@
+#include <stdlib.h>
 #include <mgdl/mgdl-light.h>
 #include <mgdl/mgdl-opengl_util.h>
 

--- a/source/cross/mgdl-logger.cpp
+++ b/source/cross/mgdl-logger.cpp
@@ -1,3 +1,4 @@
+#include <stdlib.h>
 #include <stdio.h>
 #include <mgdl/mgdl-logger.h>
 #include <mgdl/mgdl-util.h>

--- a/source/cross/mgdl-mesh.cpp
+++ b/source/cross/mgdl-mesh.cpp
@@ -1,3 +1,4 @@
+#include <stdlib.h>
 #include <mgdl/mgdl-mesh.h>
 #include <mgdl/mgdl-logger.h>
 #include <mgdl/mgdl-util.h>

--- a/source/cross/mgdl-transform.cpp
+++ b/source/cross/mgdl-transform.cpp
@@ -1,3 +1,4 @@
+#include <stdlib.h>
 #include <mgdl/mgdl-transform.h>
 
 Transform* Transform_CreateZero()

--- a/source/pc/pc-joystick-glut.cpp
+++ b/source/pc/pc-joystick-glut.cpp
@@ -1,4 +1,5 @@
 #if defined(MGDL_PLATFORM_MSYS2) || defined(MGDL_PLATFORM_MAC)
+#include <stdlib.h>
 #include <mgdl/pc/mgdl-joystick.h>
 #include <mgdl/pc/mgdl-pc-input.h>
 #include <mgdl/mgdl-logger.h>

--- a/source/pc/pc-joystick.cpp
+++ b/source/pc/pc-joystick.cpp
@@ -1,4 +1,4 @@
-
+#include <stdlib.h>
 #include <mgdl/pc/mgdl-joystick.h>
 #include <mgdl/mgdl-controller.h>
 #include <mgdl/mgdl-logger.h>


### PR DESCRIPTION
Some (hopefully all) of the fixes required to make mac build work

At least the lib builds at this state.

The example_project `make mac` does not build because of rocket issues, but commenting the rocket stuff out makes it work. Didnt include those here.